### PR TITLE
adding ability to add list of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/container-tree/tree/master) (0.0.x)
+ - adding ability to load tree from list or dictionary (0.0.04)
  - added d3 heatmap view (plotly doesn't handle large datasets) (0.0.03)
  - added tree visualization (with demo) and get_count and insert (0.0.02)
  - original release with simple function to make trie (0.0.01)

--- a/containertree/version.py
+++ b/containertree/version.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = "0.0.03"
+__version__ = "0.0.04"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'containertree'


### PR DESCRIPTION
This PR will add the check to load() if the list is already provided as a filelist. If so, it will parse through it and ensure that (likely list entries) are converted to dict, optionally with a size if the file path is found.