### PR TITLE
adding export of vectors, and docs to do it!

### DIFF
--- a/containertree/tree/base.py
+++ b/containertree/tree/base.py
@@ -31,7 +31,7 @@ from .loading import (
 
 class ContainerTreeBase(object):
 
-    def __init__(self, inputs=None, folder_sep='/', tag=None):
+    def __init__(self, inputs=None, tag=None, folder_sep='/'):
         '''construct a container tree from some export of files or 
            a string to indicate a container. This is determined by
            the subclass.

--- a/containertree/tree/container.py
+++ b/containertree/tree/container.py
@@ -20,6 +20,7 @@ from containertree.utils import check_install
 import requests
 import json
 import os
+import re
 import sys
 
 from .base import ( ContainerTreeBase, Node )
@@ -27,8 +28,8 @@ from .base import ( ContainerTreeBase, Node )
 
 class ContainerTree(ContainerTreeBase):
 
-    def __init__(self, inputs=None, folder_sep="/", tag=None):
-        super(ContainerTree, self).__init__(inputs, folder_sep, tag)
+    def __init__(self, inputs=None, tag=None, folder_sep="/"):
+        super(ContainerTree, self).__init__(inputs, tag, folder_sep)
 
     def __str__(self):
         return "ContainerTree<%s>" % self.count
@@ -165,6 +166,7 @@ class ContainerFileTree(ContainerDiffTree):
        ContainerTree, so we don't need to write a function to generate
        the tree here.
     '''
+
     def _load(self, data=None):
         return self._filter_container_diff(data, analyze_type="File")
 
@@ -221,6 +223,66 @@ class ContainerPackageTree(ContainerDiffTree):
        [{'Name': 'zlib1g', 'Size': 159744, 'Version': '1:1.2.8.dfsg-5'}..] 
     '''
 
+    def __str__(self):
+        return "Container%sTree<%s>" % (self.analyze_type, self.count)
+    def __repr__(self):
+        return "Container%sTree<%s>" % (self.analyze_type, self.count)
+
+
+    def export_vectors(self, node=None, df=None, include_tags=None, 
+                             skip_tags=None, regexp_tags=None):
+        '''export one or more vectors to describe containers mapped to a
+           package tree. Optionally, the user can include or disclude a set
+           of containers, or include/disclude version strings.
+
+           Parameters
+           ==========
+           node: the node to start the export at (default is root)
+           df: the pandas dataframe to update or continue adding to
+           include_tags: a list of container uris to include
+           skip_tags: a list o container uris to skip
+           regexp_tags: include tags based ona regular expression
+        '''
+        # Only import pandas once
+        if "pandas" not in locals():
+            import pandas
+
+        # Checks if we have initialized the df yet (can't compare to None)
+        if not hasattr(df, 'add'):
+            df = pandas.DataFrame()
+
+        if node == None:
+            node = self.root
+
+        # Skip the root node (label is '')
+        if node.label != '':
+            
+            containers = node.tags
+
+            # If the user is limiting the containers to include
+            if include_tags != None:
+                containers = containers.intersection(set(include_tags))
+
+            # If the user is skipping containers or tags
+            if skip_tags != None:
+                containers = [x for x in containers if x not in skip_tags]
+
+            # If the user wants regular expression filtering
+            if regexp_tags != None:
+                containers = [x for x in containers if re.search(regexp_tags,x)]
+
+            # Add the node packages to the tree
+            for container in containers:
+                df.loc[container, node.label] = 1
+
+        for child in node.children:
+            df = self.export_vectors(child, df, include_tags, 
+                                                skip_tags, 
+                                                regexp_tags)
+        
+        return df
+
+
     def _make_tree(self, data=None, tag=None):
         '''construct the tree from the loaded data (self.data)
            we should already have a root defined. Since we are making
@@ -256,25 +318,21 @@ class ContainerPipTree(ContainerPackageTree):
     '''a container pip tree will generate a container tree based on pip
        packages.
     '''
-    def __str__(self):
-        return "ContainerPipTree<%s>" % self.count
-    def __repr__(self):
-        return "ContainerPipTree<%s>" % self.count
+    def __init__(self, inputs=None, tag=None, folder_sep="/"):
+        self.analyze_type = "Pip"
+        super(ContainerPipTree, self).__init__(inputs, tag, folder_sep)
 
     def _load(self, data=None):
-        return self._filter_container_diff(data, analyze_type="Pip")
+        return self._filter_container_diff(data, self.analyze_type)
+
 
 class ContainerAptTree(ContainerPackageTree):
     '''a container apt tree will generate a container tree based on pip
        packages.
     '''
-    def __init__(self, inputs=None, folder_sep="/", tag=None):
-        super(ContainerTree, self).__init__(inputs, folder_sep, tag)
+    def __init__(self, inputs=None, tag=None, folder_sep="/"):
+        self.analyze_type = "Apt"
+        super(ContainerAptTree, self).__init__(inputs, tag, folder_sep)
 
     def _load(self, data=None):
-        return self._filter_container_diff(data, analyze_type="Apt")
-
-    def __str__(self):
-        return "ContainerAptTree<%s>" % self.count
-    def __repr__(self):
-        return "ContainerAptTree<%s>" % self.count
+        return self._filter_container_diff(data, self.analyze_type)

--- a/containertree/tree/loading.py
+++ b/containertree/tree/loading.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
+from containertree.logger import bot
 from containertree.utils import ( 
     check_install, 
     run_command,
@@ -57,6 +59,8 @@ def _update(self, inputs, tag=None):
     # Last effort is to run container-diff
     elif check_install(quiet=True):
         data = self._load_container_diff(inputs)
+        if not data:
+            bot.warning('No container-diff output found for %s' % inputs)
     else:
          print('Error loading %s' % inputs)
     return data

--- a/containertree/version.py
+++ b/containertree/version.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = "0.0.44"
+__version__ = "0.0.45"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'containertree'
@@ -31,3 +31,10 @@ INSTALL_REQUIRES = (
     ('requests', {'min_version': '2.18.4'}),
     ('pygments', {'min_version': '2.1.3'}),
 )
+
+
+INSTALL_ANALYSIS = (
+    ('pandas', {'min_version': None}),
+)
+
+INSTALL_REQUIRES_ALL = (INSTALL_REQUIRES + INSTALL_ANALYSIS)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ LABEL "homepage"="https://www.github.com/singularityhub/container-tree"
 LABEL "maintainer"="@vsoch"
 
 RUN apt-get update && \
-    apt-get -y install vim jq aria2 nginx python3 python3-dev \
+    apt-get -y install vim jq aria2 nginx python3 python3-dev python3-pandas \
     automake git locales && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \

--- a/docs/_docs/examples/package_tree.md
+++ b/docs/_docs/examples/package_tree.md
@@ -24,7 +24,18 @@ apt = ContainerAptTree('singularityhub/sregistry-cli')
 
 apt.trace('wget')
 # [Node<>, Node<wget>, Node<1.18-5 deb9u2>]
+
+apt.find('wget')
+# Node<wget>
+
+apt.search('bin')
+[Node<binutils>,
+ Node<libc-bin>,
+ Node<libc-dev-bin>,
+ Node<libpam-modules-bin>,
+ Node<ncurses-bin>]
 ```
+
 
 **Pip Packages**
 
@@ -43,3 +54,134 @@ pip.trace('nilearn')
 ```
 The idea would be to add containers to the tree with "update" and as you do,
 tag the nodes with the container name (or other interesting metadata).
+
+## Tagged Trees
+
+If you want to use a package tree to represent more than one container, then
+you should tag the nodes (packages) with the containers as you go. Let's
+go through the previous example with apt, but add tags to the nodes.
+
+By tagging nodes (packages) with the containers that include them, 
+we can use the data structure for interesting purposes like exporting data 
+frames (for analysis) or calculating comparisons. Let's first walk through 
+how to tag our container package trees.
+
+```python
+from containertree.tree import ContainerAptTree
+
+# Initilize a tree with packages from a container
+apt = ContainerAptTree('singularityhub/sregistry-cli', tag = 'singularityhub/sregistry-cli')
+ContainerAptTree<433>
+```
+
+Now we can see that the root node (and all package nodes) have a tag for the container!
+
+```python
+apt.root.tags
+# {'singularityhub/sregistry-cli'}
+
+wget = apt.find('wget')
+# wget.tags
+{'singularityhub/sregistry-cli'}
+```
+
+And if you add a container, you can see that the nodes tags will expand. If both
+containers have wget, the node will be tagged with both. If only one node has
+wget, you'll only see the one tag.
+
+```python
+apt.update('library/debian', tag='library/debian')
+
+find = apt.find('findutils').tags
+{'library/debian', 'singularityhub/sregistry-cli'}
+```
+
+The reason that the library doesn't do the tagging for you when you add a container
+is that it doesn't enforce how you might want to use the container package tree.
+For example, let's say that you are interested in comparing containers between
+institutions or users. Your tag might be a user or institution name.
+
+```python
+apt.update('library/debian', tag='Stanford')
+apt.update('library/ubuntu', tag='Berkeley')
+```
+
+### Export Package Data
+
+Why is this useful? If we store information at each node about the containers
+that have the packages, we can parse the tree to extract data or calculate
+similarity. Let's start with showing how to export package data. If you
+use this feature, you will additionally need the pandas module installed.
+Here are a few ways to install pandas:
+
+```bash
+pip install pandas
+pip install containertree[analysis]
+apt-get install -y python3-pandas
+```
+
+We would likely want to do some kind of analysis over container packages, and the
+first step would be to extract a data frame. Here is how to do that. First,
+create your tree and add some containers to it.
+
+```python
+from containertree.tree import ContainerAptTree
+
+# Initilize a tree with packages from a container, add others
+apt = ContainerAptTree('singularityhub/sregistry-cli', tag='singularityhub/sregistry-cli')
+apt.update('library/debian', tag='library/debian')
+apt.update('library/ubuntu', tag='library/ubuntu')
+```
+
+Here is how to export a pandas data frame with the packages:
+
+```python
+df = apt.export_vectors()
+df.head()
+
+                              adduser  3.115  3.116ubuntu1  apt  1.4.8  1.6.6  \
+library/ubuntu                    1.0    NaN           1.0  1.0    NaN    1.0   
+library/debian                    1.0    1.0           NaN  1.0    1.0    NaN   
+singularityhub/sregistry-cli      1.0    1.0           NaN  1.0    1.0    NaN   
+```
+
+The rows represent the containers, and the columns the packages. A value of
+NaN indicates the package isn't installed in the container, and 1.0 indicates
+that it is. Here is how to fill in 0 for the NaN values, if you prefer.
+
+```python
+df = df.fillna(0)
+```
+
+You can optionally subset to a particular set of tags, either including
+only a specific set:
+
+```python
+df = apt.export_vectors(include_tags=['library/debian'])
+df.head()
+                adduser  3.115  apt  1.4.8  base-files  9.9 deb9u6  \
+library/debian      1.0    1.0  1.0    1.0         1.0         1.0  
+```
+
+or skipping specific containers:
+
+
+```python
+df = apt.export_vectors(skip_tags=['library/debian'])
+df.head()
+                              adduser  3.115  3.116ubuntu1  apt  1.4.8  1.6.6  \
+library/ubuntu                    1.0    NaN           1.0  1.0    NaN    1.0   
+singularityhub/sregistry-cli      1.0    1.0           NaN  1.0    1.0    NaN
+```
+
+Or using a regular expression to filter the tags (useful for collection names,
+such as finding all containers in the "library" namespace):
+
+
+```python
+df = apt.export_vectors(regexp_tags="^library")
+df.head()
+                adduser  3.115  3.116ubuntu1  apt  1.4.8  1.6.6  base-files  \
+library/debian      1.0    1.0           NaN  1.0    1.0    NaN         1.0   
+library/ubuntu      1.0    NaN           1.0  1.0    NaN    1.0         1.0   
+```

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ LICENSE = lookup['LICENSE']
 if __name__ == "__main__":
 
     INSTALL_REQUIRES = get_reqs(lookup)
+    ANALYSIS = get_reqs(lookup, 'INSTALL_ANALYSIS')
+    INSTALL_REQUIRES_ALL = get_reqs(lookup, 'INSTALL_REQUIRES_ALL')
+
     setup(name=NAME,
           version=VERSION,
           author=AUTHOR,
@@ -79,6 +82,10 @@ if __name__ == "__main__":
           description=DESCRIPTION,
           keywords=KEYWORDS,
           install_requires = INSTALL_REQUIRES,
+          extras_require={
+              'all': [INSTALL_REQUIRES_ALL],
+              'analysis': [ANALYSIS]
+          },
           classifiers=[
               'Intended Audience :: Science/Research',
               'Intended Audience :: Developers',


### PR DESCRIPTION
This pull request will add an ability to export feature vectors (a pandas data frame) for a package tree (such as apt or pip). The pandas requirement is also added for the user to install if they want this functionality:

```
pip install containertree[analysis]
```

The function can export a data frame and optionally include/disclude tags, or filter based on a regular expression.