### PR TITLE
fixing bug with httpd containers, not using cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/container-tree/tree/master) (0.0.x)
+ - fixing bug that containers named with http/ look like urls, adding no cache (0.0.46)
  - Adding docs, extraction of container feature vectors, and bug fix (0.0.44)
  - Missing logger module (0.0.43)
  - Addition of client and start of Collection Trees (0.0.42)

--- a/containertree/tree/loading.py
+++ b/containertree/tree/loading.py
@@ -25,6 +25,7 @@ from containertree.utils import (
     get_tmpfile
 )
 import os
+import re
 import sys
 import json
 import requests

--- a/containertree/tree/loading.py
+++ b/containertree/tree/loading.py
@@ -44,7 +44,7 @@ def _update(self, inputs, tag=None):
     data = None
 
     # Load data from web / url
-    if inputs.startswith('http'):
+    if re.search("https?://", inputs):
         data = self._load_http(inputs)
 
     # Load data from file
@@ -177,7 +177,8 @@ def _load_container_diff(self, container_name, output_file=None, types=None):
 
     cmd = ["container-diff", "analyze", container_name]
     response = run_command(cmd + types + ["--output", output_file, "--json",
-                                          "--quiet","--verbosity=panic"])
+                                          "--quiet", "--no-cache",
+                                          "--verbosity=panic"])
 
     if response['return_code'] == 0 and os.path.exists(output_file):
         layers = read_json(output_file)

--- a/containertree/version.py
+++ b/containertree/version.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = "0.0.45"
+__version__ = "0.0.46"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'containertree'

--- a/docs/_docs/examples/export_data.md
+++ b/docs/_docs/examples/export_data.md
@@ -116,4 +116,3 @@ singularityhub/container-tree               1.0             1.0        1.0
                                setuptools-v40.6.3  six-v1.10.0  wheel-v0.32.3  
 singularityhub/container-tree                 1.0          1.0            1.0  
 ```
-


### PR DESCRIPTION
This pull request will close #32, ensuring that container-diff doesn't cache layers, and #34 , a bug that a container named with http is treated like a url (and it should not be.)