### PR TITLE
fixing bug with load file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/container-tree/tree/master) (0.0.x)
+ - load_file should be renamed to load_json (0.0.47)
  - fixing bug that containers named with http/ look like urls, adding no cache (0.0.46)
  - Adding docs, extraction of container feature vectors, and bug fix (0.0.44)
  - Missing logger module (0.0.43)

--- a/containertree/tree/loading.py
+++ b/containertree/tree/loading.py
@@ -51,7 +51,8 @@ def _update(self, inputs, tag=None):
     # Load data from file
     elif os.path.exists(inputs):
         if inputs.endswith('json'):
-            data = self._load_file(inputs)
+            data = self._load_json(inputs)
+
         # Otherwise, pass on the filepath to the _load function
         else:
             print('Unrecognized extension, passing %s to _load subclass' % inputs) 

--- a/containertree/version.py
+++ b/containertree/version.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = "0.0.46"
+__version__ = "0.0.47"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'containertree'


### PR DESCRIPTION
This will fix a bug that a function was renamed to load from a file, but it should be load_file and not load_json.