### PR TITLE
fix link to contributing guides

### DIFF
--- a/docs/_docs/contributing/index.md
+++ b/docs/_docs/contributing/index.md
@@ -7,8 +7,8 @@ order: 1
 
 It's so great that you want to contribute! There are several ways to contribute.
 
- - [Contribute to Documentation]({{ site.url }}{{ site.baseurl }}/contributing/docs/)
- - [Contribute Code]({{ site.url }}{{ site.baseurl }}/contributing/code/)
+ - [Contribute to Documentation]({{ site.baseurl }}/contributing/docs/)
+ - [Contribute Code]({{ site.baseurl }}/contributing/code/)
  - Ask a question, report a bug, or suggest a feature by opening up an [issue](https://www.github.com/{{ site.repo }}/issues)
 
 Whether you ask a question, help to update the code with a bug fix, or


### PR DESCRIPTION
Contributing guides had an extra `/container-tree` in the links:
https://singularityhub.github.io/container-tree/container-tree/contributing/docs/
instead of
https://singularityhub.github.io/container-tree/contributing/docs/

Removed `{{ site.baseurl }}` from links, and now they should be working.

(part of the [JOSS review](https://github.com/openjournals/joss-reviews/issues/1418))